### PR TITLE
Add latest posts feature for CoverPage (Closes: #9)

### DIFF
--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -12,15 +12,9 @@ CoverBackground {
         spacing: Theme.paddingLarge
 
         Label {
+            id: header
             text: "Latest posts"
             font.pixelSize: Theme.fontSizeSmall
-        }
-
-        Label {
-            id: busy
-            visible: false
-            text: "Loading..."
-            font.pixelSize: Theme.fontSizeTiny
         }
 
         Repeater {
@@ -40,7 +34,16 @@ CoverBackground {
         }
     }
 
-    /* Possible implementation later when connected to updateView
+    BusyIndicator {
+        anchors.centerIn: parent
+        visible: application.fetching
+    }
+
+    Label {
+        anchors.centerIn: parent
+        visible: application.latest.count === 0 && !application.fetching
+        text: "No posts found"
+    }
 
     CoverActionList {
         id: coverAction
@@ -53,5 +56,5 @@ CoverBackground {
             }
         }
 
-    } */
+    }
 }

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -2,12 +2,56 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 CoverBackground {
-    Label {
-        id: label
-        anchors.verticalCenter: parent.verticalCenter
-        width: parent.width
-        text: qsTr("SFOS Forum Viewer")
-        horizontalAlignment: Text.AlignHCenter
-        wrapMode: Text.Wrap
+
+    Column {
+        id: col
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.margins: Theme.paddingLarge
+        spacing: Theme.paddingLarge
+
+        Label {
+            text: "Latest posts"
+            font.pixelSize: Theme.fontSizeSmall
+        }
+
+        Label {
+            id: busy
+            visible: false
+            text: "Loading..."
+            font.pixelSize: Theme.fontSizeTiny
+        }
+
+        Repeater {
+            model: application.latest
+
+            Column {
+                width: col.width
+                spacing: Theme.paddingSmall
+
+                Label {
+                    width: col.width
+                    elide: Text.ElideRight
+                    text: title
+                    font.pixelSize: Theme.fontSizeTiny
+                }
+            }
+        }
     }
+
+    /* Possible implementation later when connected to updateView
+
+    CoverActionList {
+        id: coverAction
+
+        CoverAction {
+            iconSource: "image://theme/icon-cover-refresh"
+
+            onTriggered: {
+                application.fetchLatestPosts()
+            }
+        }
+
+    } */
 }

--- a/qml/harbour-sfos-forum-viewer.qml
+++ b/qml/harbour-sfos-forum-viewer.qml
@@ -4,7 +4,9 @@ import "pages"
 
 ApplicationWindow
 {
+    id: application
     initialPage: Component { FirstPage { } }
     cover: Qt.resolvedUrl("cover/CoverPage.qml")
+    property var latest: ListModel{id: latest}
     allowedOrientations: defaultAllowedOrientations
 }

--- a/qml/harbour-sfos-forum-viewer.qml
+++ b/qml/harbour-sfos-forum-viewer.qml
@@ -7,6 +7,53 @@ ApplicationWindow
     id: application
     initialPage: Component { FirstPage { } }
     cover: Qt.resolvedUrl("cover/CoverPage.qml")
+    property bool fetching: false
     property var latest: ListModel{id: latest}
-    allowedOrientations: defaultAllowedOrientations
+    property string source: "https://forum.sailfishos.org/"
+    property string tid
+    property int pageno: 0
+    property string viewmode : "latest"
+    property string textname
+    property string pagetitle:  textname == "" ? "SFOS Forum - " + viewmode : "SFOS Forum - " + textname
+    property string combined: tid == "" ? source + viewmode + ".json?page=" + pageno : source + "c/" + tid + ".json?page=" + pageno
+
+    function fetchLatestPosts() {
+        application.latest.clear()
+        fetching = true
+        var xhr = new XMLHttpRequest;
+        xhr.open("GET", combined);
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === XMLHttpRequest.DONE) {
+                var data = JSON.parse(xhr.responseText);
+
+                if (viewmode === "latest" && tid === ""){
+
+                for (var i=0;i<data.topic_list.topics.length;i++) {
+                    if ("bumped" in data.topic_list.topics[i] && data.topic_list.topics[i]["bumped"] === true){
+                        if (i <= 4) {
+                            application.latest.append({title: data.topic_list.topics[i]["title"]})
+                        }
+                    }
+                }
+
+            } else {
+                    for (var j=0;j<data.topic_list.topics.length;j++) {
+                        if (j < 4) {
+                            application.latest.append({title: data.topic_list.topics[j]["title"]})
+                        }
+                    }
+
+            }
+                var more = 'more_topics_url';
+                if (data.topic_list[more]){
+                    pageno++;
+                } else {
+                    pageno = 0;
+                }
+            }
+
+            fetching = false
+        }
+        xhr.send();
+    }
 }

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -3,7 +3,7 @@ import Sailfish.Silica 1.0
 
 
  Page {
-    id: firstPage
+        id: firstPage
         allowedOrientations: Orientation.All
         property string source: "https://forum.sailfishos.org/"
         property string tid
@@ -12,9 +12,11 @@ import Sailfish.Silica 1.0
         property string textname
         property string pagetitle:  textname == "" ? "SFOS Forum - " + viewmode : "SFOS Forum - " + textname
         property string combined: tid == "" ? source + viewmode + ".json?page=" + pageno : source + "c/" + tid + ".json?page=" + pageno
+        property bool fetching: false
 
         function updateview() {
             var xhr = new XMLHttpRequest;
+            fetching = true
             xhr.open("GET", combined);
             xhr.onreadystatechange = function() {
                 if (xhr.readyState === XMLHttpRequest.DONE) {
@@ -51,12 +53,21 @@ import Sailfish.Silica 1.0
                         pageno = 0;
 
                         }
-
                 }
             }
-
+            fetching = false
+            updateApplicationData()
             xhr.send();
+        }
 
+        function updateApplicationData() {
+            application.tid = tid
+            application.pageno = pageno
+            application.viewmode = viewmode
+            application.textname = textname
+            application.pagetitle = pagetitle
+            application.combined = combined
+            application.fetching = fetching
         }
 
     SilicaListView {

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -13,28 +13,33 @@ import Sailfish.Silica 1.0
         property string pagetitle:  textname == "" ? "SFOS Forum - " + viewmode : "SFOS Forum - " + textname
         property string combined: tid == "" ? source + viewmode + ".json?page=" + pageno : source + "c/" + tid + ".json?page=" + pageno
 
-
-        function updateview(){
+        function updateview() {
             var xhr = new XMLHttpRequest;
             xhr.open("GET", combined);
             xhr.onreadystatechange = function() {
                 if (xhr.readyState === XMLHttpRequest.DONE) {
                     var data = JSON.parse(xhr.responseText);
                     //list.model.clear();
-
+                    application.latest.clear()
 
                     if (viewmode === "latest" && tid === ""){
 
                     for (var i=0;i<data.topic_list.topics.length;i++) {
                         if ("bumped" in data.topic_list.topics[i] && data.topic_list.topics[i]["bumped"] === true){
                         list.model.append({title: data.topic_list.topics[i]["title"], topicid: data.topic_list.topics[i]["id"], posts_count: data.topic_list.topics[i]["posts_count"]});
+
+                        if (i <= 4) {
+                            application.latest.append({title: data.topic_list.topics[i]["title"]})
+                        }
                     }
                     }
 
                 } else {
                         for (var j=0;j<data.topic_list.topics.length;j++) {
-
                             list.model.append({title: data.topic_list.topics[j]["title"], topicid: data.topic_list.topics[j]["id"], posts_count: data.topic_list.topics[j]["posts_count"]});
+                            if (j < 4) {
+                                application.latest.append({title: data.topic_list.topics[j]["title"]})
+                            }
                         }
 
                         }


### PR DESCRIPTION
**Description**
Add some practical coverpage functionality based on #9. This PR also adds the refresh option on coverpage and error handling on the case that no posts are found etc. 

**Note about changes**
Since this doesn't just add a component / feature, I wanted to give a little note / changelog on what have been changed too
- Give id "application" to ApplicationWindow. Can be accessed now from other pages too
- Copy the XMLHttp request required properties as global properties on ApplicationWindow
- Add a function which updates the local page data after reload to global data
- Add a function fetchLatestPosts() on ApplicationWindow which CoverPage uses to fetch data

If we want to move the whole XMLHttp request stuff on to the ApplicationWindow, I think this should be done in further improvements later. I didn't want to modify our current implementation too much since there's quite lot refactoring considering the pageStack.push operations that pass the data when moving another page. A good thing now is that more application related data is available globally on other pages too by using the id "application".

**Screenshots**
![viewImage](http://puu.sh/GdI0g/62c206cc47.jpg)

I tested on my Xperia XA2 and the coverpage runs smoothly. 