### PR TITLE
[trivial] add dependencies for OBS building

### DIFF
--- a/rpm/harbour-sfos-forum-viewer.spec
+++ b/rpm/harbour-sfos-forum-viewer.spec
@@ -27,6 +27,8 @@ Requires:   libsailfishcryptoplugin
 Requires:   sailfishsecretsdaemon-cryptoplugins-default
 Requires:   sailfishsecretsdaemon-secretsplugins-default
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.3
+BuildRequires:  pkgconfig(sailfishsecrets)
+BuildRequires:  pkgconfig(sailfishcrypto)
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)

--- a/rpm/harbour-sfos-forum-viewer.yaml
+++ b/rpm/harbour-sfos-forum-viewer.yaml
@@ -21,6 +21,8 @@ Builder: qmake5
 # This is the preferred way of specifying build dependencies for your package.
 PkgConfigBR:
   - sailfishapp >= 1.0.3
+  - sailfishsecrets
+  - sailfishcrypto
   - Qt5Core
   - Qt5Qml
   - Qt5Quick


### PR DESCRIPTION
In minimal build environments these may not be installed, so add them to the spec/yaml BuildRequires.

- pkgconfig(sailfishsecrets)
- pkgconfig(sailfishcrypto)