### PR TITLE
Use authenticated requests if possible (fixes #60)

### DIFF
--- a/qml/harbour-sfos-forum-viewer.qml
+++ b/qml/harbour-sfos-forum-viewer.qml
@@ -52,6 +52,7 @@ ApplicationWindow
         id: loggedin
         key: "/apps/harbour-sfos-forum-viewer/key"
     }
+
     property QtObject categories: QtObject {
         property bool networkError: false
         property var model: ListModel { id: categoriesModel }
@@ -60,7 +61,7 @@ ApplicationWindow
         function fetch() {
             var xhr = new XMLHttpRequest;
             xhr.open("GET", application.source + "categories.json?include_subcategories=true");
-            if (loggedin.value != -1) xhr.setRequestHeader("User-Api-Key", loggedin.value);
+            if (loggedin.value && (loggedin.value != -1)) xhr.setRequestHeader("User-Api-Key", loggedin.value);
             xhr.onreadystatechange = function() {
                 if (xhr.readyState === XMLHttpRequest.DONE) {
                     if (xhr.responseText === "") {
@@ -125,7 +126,7 @@ ApplicationWindow
         fetching = true
         var xhr = new XMLHttpRequest;
         xhr.open("GET", source + "latest.json");
-        if (loggedin.value != -1) xhr.setRequestHeader("User-Api-Key", loggedin.value);
+        if (loggedin.value && (loggedin.value != -1)) xhr.setRequestHeader("User-Api-Key", loggedin.value);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 if (xhr.responseText !== "") {

--- a/qml/harbour-sfos-forum-viewer.qml
+++ b/qml/harbour-sfos-forum-viewer.qml
@@ -27,6 +27,7 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import Nemo.Configuration 1.0
 import "pages"
 
 ApplicationWindow
@@ -47,6 +48,10 @@ ApplicationWindow
     //: date format including date and time but no weekday
     readonly property string dateTimeFormat: qsTr("d/M/yyyy '('hh':'mm')'")
 
+    ConfigurationValue {
+        id: loggedin
+        key: "/apps/harbour-sfos-forum-viewer/key"
+    }
     property QtObject categories: QtObject {
         property bool networkError: false
         property var model: ListModel { id: categoriesModel }
@@ -55,6 +60,7 @@ ApplicationWindow
         function fetch() {
             var xhr = new XMLHttpRequest;
             xhr.open("GET", application.source + "categories.json?include_subcategories=true");
+            if (loggedin.value != -1) xhr.setRequestHeader("User-Api-Key", loggedin.value);
             xhr.onreadystatechange = function() {
                 if (xhr.readyState === XMLHttpRequest.DONE) {
                     if (xhr.responseText === "") {
@@ -119,6 +125,7 @@ ApplicationWindow
         fetching = true
         var xhr = new XMLHttpRequest;
         xhr.open("GET", source + "latest.json");
+        if (loggedin.value != -1) xhr.setRequestHeader("User-Api-Key", loggedin.value);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 if (xhr.responseText !== "") {

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -121,6 +121,7 @@ Page {
         var xhr = new XMLHttpRequest;
 
         xhr.open("GET", combined);
+        xhr.setRequestHeader("User-Api-Key", loggedin.value);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 if (xhr.responseText === "") {
@@ -226,10 +227,12 @@ Page {
         clearview();
 
     }
+
     ConfigurationValue {
         id: loggedin
         key: "/apps/harbour-sfos-forum-viewer/key"
     }
+
     ConfigurationValue {
         id: checkem
         key: "/apps/harbour-sfos-forum-viewer/checkem"

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -121,7 +121,7 @@ Page {
         var xhr = new XMLHttpRequest;
 
         xhr.open("GET", combined);
-        xhr.setRequestHeader("User-Api-Key", loggedin.value);
+        if (loggedin.value !== "-1") xhr.setRequestHeader("User-Api-Key", loggedin.value);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 if (xhr.responseText === "") {

--- a/qml/pages/ThreadView.qml
+++ b/qml/pages/ThreadView.qml
@@ -60,6 +60,7 @@ Page {
     function getRedirect(link){
         var xhr = new XMLHttpRequest;
         xhr.open("GET", link);
+        if (loggedin.value != "-1") xhr.setRequestHeader("User-Api-Key", loggedin.value);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
                 var xhrlocation = xhr.getResponseHeader("location");


### PR DESCRIPTION
As we talked about in #60, this enables viewing posts/categories which require a login/authentication.

Have been using this for a while, seems to work okay.