### PR TITLE
Allow messages to be marked read from the front page

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -382,10 +382,10 @@ Page {
             showLatest();
         }
 
-        delegate: BackgroundItem {
+        delegate: ListItem {
             id: item
             width: parent.width
-            height: delegateCol.height + Theme.paddingLarge
+            contentHeight: delegateCol.height + Theme.paddingLarge
 
             property int lastPostNumber: postCountConfig.value(topicid, -1)
             property bool hasNews: (lastPostNumber > 0 && lastPostNumber < highest_post_number)
@@ -525,6 +525,14 @@ Page {
                 }
             }
 
+            menu: ContextMenu {
+                      MenuItem { text: qsTr("Mark as Read")
+                          onDelayedClick: {
+                              postCountConfig.setValue(topicid, highest_post_number);
+                              lastPostNumber = highest_post_number;
+                          }
+                      }
+            }
             onClicked: {
                 var name = list.model.get(index).name
                 postCountConfig.setValue(topicid, highest_post_number);

--- a/translations/harbour-sfos-forum-viewer-de.ts
+++ b/translations/harbour-sfos-forum-viewer-de.ts
@@ -150,6 +150,10 @@ Vielen Dank an die Mitwirkenden:
         <source>tags</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark as Read</source>
+        <translation>Als Gelesen markieren</translation>
+    </message>
 </context>
 <context>
     <name>NewPost</name>


### PR DESCRIPTION
Adds the option to mark Threads as read by long-pressing them in the list.