### PR TITLE
Set topic tracking level via API call

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -556,10 +556,11 @@ Page {
                             //visible: has_accepted_answer
                             //source: "image://theme/icon-s-accept"
                             visible: source != ""
-                            source: has_accepted_answer ? "image://theme/icon-s-accept?" + Theme.highlightFromColor(Theme.presenceColor(Theme.PresenceAvailable), Theme.colorScheme )
-                                                        : ((notification_level >= 0)
-                                                            ? watchlevel[notification_level].smallicon
-                                                            : "")
+                            source: has_accepted_answer
+                                        ? "image://theme/icon-s-accept?" + Theme.highlightFromColor(Theme.presenceColor(Theme.PresenceAvailable), Theme.colorScheme )
+                                        : ((notification_level >= 0)
+                                            ? watchlevel[notification_level].smallicon
+                                            : "")
                             width: Theme.iconSizeSmall
                             height: width
                             opacity: has_accepted_answer ? Theme.opacityLow : 1.0

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -631,7 +631,7 @@ Page {
                 hasContent: lastPostNumber > 0 || !loadedMore
                 property int wantLevel: notification_level
                 onClosed: if (wantLevel != notification_level) {
-                    setNotificationLevel(item.index, topicid, wantLevel)
+                    setNotificationLevel(topicid, wantLevel)
                 }
                 MenuItem { text: qsTr("Mark as read")
                     visible: lastPostNumber > 0 && lastPostNumber < highest_post_number

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -546,7 +546,7 @@ Page {
                                                             : "")
                             width: Theme.iconSizeSmall
                             height: width
-                            opacity: (notification_level > 1) ? postsLabel.opacity : Theme.opacityLow
+                            opacity: has_accepted_answer ? Theme.opacityLow : 1.0
                         }
                     }
 

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -635,40 +635,40 @@ Page {
                 /*
                 MenuLabel { text: ""; height: sl.height
                     Slider{ id: sl
-                    width: parent.width
-                    stepSize: 1
-                    minimumValue: 0
-                    maximumValue: 3
-                    value: notification_level
-                    valueText: watchlevels[sliderValue]
-                    label: qsTr("Tracking Level")
+                        width: parent.width
+                        stepSize: 1
+                        minimumValue: 0
+                        maximumValue: 3
+                        value: notification_level
+                        valueText: watchlevels[sliderValue]
+                        label: qsTr("Tracking Level")
+                    }
                 }
-            }
-            */
-            MenuItem { text: qsTr("Mute")
-                visible: (notification_level != 0)
-                onDelayedClick: {
-                    // muting hides the topic completely, with no way in the app to undo.
-                    // so, lets remorse it.
-                    Remorse.itemAction(item, qsTr("Muted"), function() { const newlevel = "0"; setNotificationLevel(topicid, newlevel) })
+                */
+                MenuItem { text: qsTr("Mute")
+                    visible: (notification_level != 0)
+                    onDelayedClick: {
+                        // muting hides the topic completely, with no way in the app to undo.
+                        // so, lets remorse it.
+                        Remorse.itemAction(item, qsTr("Muted"), function() { const newlevel = "0"; setNotificationLevel(topicid, newlevel) })
+                    }
                 }
-            }
-            MenuItem { text: qsTr("Normal")
+                MenuItem { text: qsTr("Normal")
                     visible: (notification_level != 1)
                     onDelayedClick: {
                         const newlevel = "1"
                         setNotificationLevel(topicid, newlevel)
                     }
-            }
-            MenuItem { text: qsTr("Track")
-                visible: (notification_level < 2)
-                onDelayedClick: {
-                    const newlevel = "2"
-                    setNotificationLevel(topicid, newlevel)
                 }
-            }
-            // only shown when state is Tracking, keep the menu shorter
-            MenuItem { text: qsTr("Watch")
+                MenuItem { text: qsTr("Track")
+                    visible: (notification_level < 2)
+                    onDelayedClick: {
+                        const newlevel = "2"
+                        setNotificationLevel(topicid, newlevel)
+                    }
+                }
+                // only shown when state is Tracking, keep the menu shorter
+                MenuItem { text: qsTr("Watch")
                     visible: (notification_level == 2)
                     onDelayedClick: {
                         const newlevel = "3"
@@ -692,7 +692,6 @@ Page {
                         filterlist.setValue(spamop, getusername(spamop));
                         filterlist.sync();
                         clearview();
-
                     }
                 }
             }

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -169,7 +169,8 @@ Page {
                                           spamop: topic.posters[0].user_id,
                                           user_id: spammerop,
                                           has_accepted_answer: topic.has_accepted_answer,
-                                          highest_post_number: topic.highest_post_number
+                                          highest_post_number: topic.highest_post_number,
+                                          notification_level: topic.notification_level
                                       });
                     console.log(topic.posters[0].user_id);
                 }

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -684,7 +684,7 @@ Page {
                                     Label {
                                         anchors.horizontalCenter: icon.horizontalCenter
                                         text: modelData.action
-                                        font.pixelSize: Theme.fontSizeSmall
+                                        font.pixelSize: Theme.fontSizeExtraSmall
                                         color: icon.highlighted ? Theme.highlightColor : Theme.primaryColor
                                         highlighted: icon.highlighted
                                     }

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -251,14 +251,15 @@ Page {
 
     }
 
-    readonly property var watchlevels: [
-            qsTr("Muted",    "Topic watch level"),
-            qsTr("Normal",   "Topic watch level"),
-            qsTr("Tracking", "Topic watch level"),
-            qsTr("Watching", "Topic watch level")
+    readonly property var watchlevel: [
+        //{ "name": qsTr("Muted",    "Topic watch level"), "action": qsTr("Mute",   "Topic watch action (verb)"), "icon": "image://theme/icon-s-blocked" },
+        { "name": qsTr("Muted",    "Topic watch level (state)"), "action": qsTr("Mute",   "Topic watch action (verb)"), "icon": "image://theme/icon-m-speaker-mute" },
+        { "name": qsTr("Normal",   "Topic watch level (state)"), "action": qsTr("Normal", "Topic watch action (verb)"), "icon": "image://theme/icon-m-favorite" },
+        { "name": qsTr("Tracking", "Topic watch level (state)"), "action": qsTr("Track",  "Topic watch action (verb)"), "icon": "image://theme/icon-m-favorite-selected" },
+        { "name": qsTr("Watching", "Topic watch level (state)"), "action": qsTr("Watch",  "Topic watch action (verb)"), "icon": "image://theme/icon-splus-show-password" }
     ]
     function setNotificationLevel(topicid, level){
-        console.debug("Setting watch level to", level, ",", watchlevels[Number(level)])
+        console.debug("Setting watch level to", level, ",", watchlevel[Number(level)].name)
         var xhr = new XMLHttpRequest;
         const json = {
             // 0, 1, 2, 3
@@ -624,7 +625,7 @@ Page {
 
             menu: ContextMenu {
                 hasContent: lastPostNumber > 0 || !loadedMore
-                MenuLabel { text: watchlevels[notification_level]; visible: (notification_level >=0) }
+                MenuLabel { text: !!watchlevel[notification_level] ? watchlevel[notification_level].name : ""; visible: (notification_level >=0) }
                 MenuItem { text: qsTr("Mark as read")
                     visible: lastPostNumber > 0 && lastPostNumber < highest_post_number
                     onDelayedClick: {
@@ -640,12 +641,12 @@ Page {
                         minimumValue: 0
                         maximumValue: 3
                         value: notification_level
-                        valueText: watchlevels[sliderValue]
+                        valueText: watchlevel[sliderValue].name
                         label: qsTr("Tracking Level")
                     }
                 }
                 */
-                MenuItem { text: qsTr("Mute")
+                MenuItem { text: watchlevel[0].action // "Mute"
                     visible: (notification_level >= 0) && (notification_level != 0)
                     onDelayedClick: {
                         // muting hides the topic completely, with no way in the app to undo.
@@ -653,14 +654,14 @@ Page {
                         Remorse.itemAction(item, qsTr("Muted"), function() { const newlevel = "0"; setNotificationLevel(topicid, newlevel) })
                     }
                 }
-                MenuItem { text: qsTr("Normal")
+                MenuItem { text: watchlevel[1].action // "Normal"
                     visible: (notification_level >= 0) && (notification_level != 1)
                     onDelayedClick: {
                         const newlevel = "1"
                         setNotificationLevel(topicid, newlevel)
                     }
                 }
-                MenuItem { text: qsTr("Track")
+                MenuItem { text: watchlevel[2].action  // "Track"
                     visible: (notification_level >= 0) && (notification_level < 2)
                     onDelayedClick: {
                         const newlevel = "2"
@@ -668,7 +669,7 @@ Page {
                     }
                 }
                 // only shown when state is Tracking, keep the menu shorter
-                MenuItem { text: qsTr("Watch")
+                MenuItem { text: watchlevel[3].action // "Watch"
                     visible: (notification_level >= 0) && (notification_level == 2)
                     onDelayedClick: {
                         const newlevel = "3"

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -624,6 +624,7 @@ Page {
 
             menu: ContextMenu {
                 hasContent: lastPostNumber > 0 || !loadedMore
+                MenuLabel { text: watchlevels[notification_level] }
                 MenuItem { text: qsTr("Mark as read")
                     visible: lastPostNumber > 0 && lastPostNumber < highest_post_number
                     onDelayedClick: {
@@ -631,6 +632,50 @@ Page {
                         lastPostNumber = highest_post_number;
                     }
                 }
+                /*
+                MenuLabel { text: ""; height: sl.height
+                    Slider{ id: sl
+                    width: parent.width
+                    stepSize: 1
+                    minimumValue: 0
+                    maximumValue: 3
+                    value: notification_level
+                    valueText: watchlevels[sliderValue]
+                    label: qsTr("Tracking Level")
+                }
+            }
+            */
+            MenuItem { text: qsTr("Mute")
+                visible: (notification_level != 0)
+                onDelayedClick: {
+                    // muting hides the topic completely, with no way in the app to undo.
+                    // so, lets remorse it.
+                    Remorse.itemAction(item, qsTr("Muted"), function() { const newlevel = "0"; setNotificationLevel(topicid, newlevel) })
+                }
+            }
+            MenuItem { text: qsTr("Normal")
+                    visible: (notification_level != 1)
+                    onDelayedClick: {
+                        const newlevel = "1"
+                        setNotificationLevel(topicid, newlevel)
+                    }
+            }
+            MenuItem { text: qsTr("Track")
+                visible: (notification_level < 2)
+                onDelayedClick: {
+                    const newlevel = "2"
+                    setNotificationLevel(topicid, newlevel)
+                }
+            }
+            // only shown when state is Tracking, keep the menu shorter
+            MenuItem { text: qsTr("Watch")
+                    visible: (notification_level == 2)
+                    onDelayedClick: {
+                        const newlevel = "3"
+                        setNotificationLevel(topicid, newlevel)
+                    }
+                }
+                /*
                 MenuItem { text: qsTr("Don't track")
                     visible: lastPostNumber > 0
                     onDelayedClick: {
@@ -638,6 +683,7 @@ Page {
                         lastPostNumber = -1;
                     }
                 }
+                */
                 MenuItem { text: qsTr("Filter OP")
                     visible: !loadedMore
                     onDelayedClick: {

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -170,7 +170,7 @@ Page {
                                           user_id: spammerop,
                                           has_accepted_answer: topic.has_accepted_answer,
                                           highest_post_number: topic.highest_post_number,
-                                          notification_level: topic.notification_level
+                                          notification_level: (loggedin.value == "-1") ? "-1" : topic.notification_level
                                       });
                     console.log(topic.posters[0].user_id);
                 }
@@ -624,7 +624,7 @@ Page {
 
             menu: ContextMenu {
                 hasContent: lastPostNumber > 0 || !loadedMore
-                MenuLabel { text: watchlevels[notification_level] }
+                MenuLabel { text: watchlevels[notification_level]; visible: (notification_level >=0) }
                 MenuItem { text: qsTr("Mark as read")
                     visible: lastPostNumber > 0 && lastPostNumber < highest_post_number
                     onDelayedClick: {
@@ -646,7 +646,7 @@ Page {
                 }
                 */
                 MenuItem { text: qsTr("Mute")
-                    visible: (notification_level != 0)
+                    visible: (notification_level >= 0) && (notification_level != 0)
                     onDelayedClick: {
                         // muting hides the topic completely, with no way in the app to undo.
                         // so, lets remorse it.
@@ -654,14 +654,14 @@ Page {
                     }
                 }
                 MenuItem { text: qsTr("Normal")
-                    visible: (notification_level != 1)
+                    visible: (notification_level >= 0) && (notification_level != 1)
                     onDelayedClick: {
                         const newlevel = "1"
                         setNotificationLevel(topicid, newlevel)
                     }
                 }
                 MenuItem { text: qsTr("Track")
-                    visible: (notification_level < 2)
+                    visible: (notification_level >= 0) && (notification_level < 2)
                     onDelayedClick: {
                         const newlevel = "2"
                         setNotificationLevel(topicid, newlevel)
@@ -669,7 +669,7 @@ Page {
                 }
                 // only shown when state is Tracking, keep the menu shorter
                 MenuItem { text: qsTr("Watch")
-                    visible: (notification_level == 2)
+                    visible: (notification_level >= 0) && (notification_level == 2)
                     onDelayedClick: {
                         const newlevel = "3"
                         setNotificationLevel(topicid, newlevel)

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -258,16 +258,15 @@ Page {
         { "name": qsTr("Tracking", "Topic watch level (state)"), "action": qsTr("Track",  "Topic watch action (verb)"), "icon": "image://theme/icon-m-favorite-selected" },
         { "name": qsTr("Watching", "Topic watch level (state)"), "action": qsTr("Watch",  "Topic watch action (verb)"), "icon": "image://theme/icon-splus-show-password" }
     ]
+    // level being one of 0, 1, 2, 3; erepresenting muted, normal, tracking, watching
+    // !! payload wants a string so "0", not 0
     function setNotificationLevel(topicid, level){
         console.debug("Setting watch level to", level, ",", watchlevel[Number(level)].name)
         var xhr = new XMLHttpRequest;
         const json = {
-            // 0, 1, 2, 3
-            // muted, normal, tracking, watching
-            // string! so "0", not 0
             "notification_level": level
         };
-        xhr.open("POST", "https://forum.sailfishos.org/t/" + topicid + "/notifications.json");
+        xhr.open("POST", application.source + "/t/" + topicid + "/notifications.json");
         xhr.setRequestHeader("User-Api-Key", loggedin.value);
         xhr.setRequestHeader("Content-Type", 'application/json');
         xhr.onreadystatechange = function() {

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -252,11 +252,26 @@ Page {
     }
 
     readonly property var watchlevel: [
-        //{ "name": qsTr("Muted",    "Topic watch level"), "action": qsTr("Mute",   "Topic watch action (verb)"), "icon": "image://theme/icon-s-blocked" },
-        { "name": qsTr("Muted",    "Topic watch level (state)"), "action": qsTr("Mute",   "Topic watch action (verb)"), "icon": "image://theme/icon-m-speaker-mute" },
-        { "name": qsTr("Normal",   "Topic watch level (state)"), "action": qsTr("Normal", "Topic watch action (verb)"), "icon": "image://theme/icon-m-favorite" },
-        { "name": qsTr("Tracking", "Topic watch level (state)"), "action": qsTr("Track",  "Topic watch action (verb)"), "icon": "image://theme/icon-m-favorite-selected" },
-        { "name": qsTr("Watching", "Topic watch level (state)"), "action": qsTr("Watch",  "Topic watch action (verb)"), "icon": "image://theme/icon-splus-show-password" }
+        { "name": qsTr("Muted",    "Topic watch level (state)"),
+          "action": qsTr("Mute",   "Topic watch action (verb)"),
+          "smallicon": "image://theme/icon-m-speaker-mute",
+          "icon": "image://theme/icon-m-speaker-mute"
+        },
+        { "name": qsTr("Normal",   "Topic watch level (state)"),
+          "action": qsTr("Normal", "Topic watch action (verb)"),
+          "smallicon": "",
+          "icon": "image://theme/icon-m-favorite"
+        },
+        { "name": qsTr("Tracking", "Topic watch level (state)"),
+          "action": qsTr("Track",  "Topic watch action (verb)"),
+          "smallicon": "image://theme/icon-m-favorite",
+          "icon": "image://theme/icon-m-favorite-selected"
+        },
+        { "name": qsTr("Watching", "Topic watch level (state)"),
+          "action": qsTr("Watch",  "Topic watch action (verb)"),
+          "smallicon": "image://theme/icon-m-alarm",
+          "icon": "image://theme/icon-m-alarm"
+        }
     ]
     // level being one of 0, 1, 2, 3; representing muted, normal, tracking, watching
     // !! payload wants a string so "0", not 0
@@ -543,7 +558,7 @@ Page {
                             visible: source != ""
                             source: has_accepted_answer ? "image://theme/icon-s-accept?" + Theme.highlightFromColor(Theme.presenceColor(Theme.PresenceAvailable), Theme.colorScheme )
                                                         : ((notification_level >= 0)
-                                                            ? watchlevel[notification_level].icon + "?" + Theme.rgba(postsLabel.color, 1.0)
+                                                            ? watchlevel[notification_level].smallicon
                                                             : "")
                             width: Theme.iconSizeSmall
                             height: width

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -250,6 +250,39 @@ Page {
 
     }
 
+    readonly property var watchlevels: [
+            qsTr("Muted",    "Topic watch level"),
+            qsTr("Normal",   "Topic watch level"),
+            qsTr("Tracking", "Topic watch level"),
+            qsTr("Watching", "Topic watch level")
+    ]
+    function setNotificationLevel(topicid, level){
+        console.debug("Setting watch level to", level, ",", watchlevels[Number(level)])
+        var xhr = new XMLHttpRequest;
+        const json = {
+            // 0, 1, 2, 3
+            // muted, normal, tracking, watching
+            // string! so "0", not 0
+            "notification_level": level
+        };
+        xhr.open("POST", "https://forum.sailfishos.org/t/" + topicid + "/notifications.json");
+        xhr.setRequestHeader("User-Api-Key", loggedin.value);
+        xhr.setRequestHeader("Content-Type", 'application/json');
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === XMLHttpRequest.DONE){
+                if(xhr.statusText !== "OK"){
+                    pageStack.completeAnimation();
+                    pageStack.push("Error.qml", {errortext: xhr.responseText});
+                } else {
+                    console.log(xhr.responseText);
+                    // FIXME: update to reload the topic properties
+                    clearview()
+                }
+            }
+        }
+        xhr.send(JSON.stringify(json));
+    }
+
     ConfigurationValue {
         id: loggedin
         key: "/apps/harbour-sfos-forum-viewer/key"

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -258,9 +258,10 @@ Page {
         { "name": qsTr("Tracking", "Topic watch level (state)"), "action": qsTr("Track",  "Topic watch action (verb)"), "icon": "image://theme/icon-m-favorite-selected" },
         { "name": qsTr("Watching", "Topic watch level (state)"), "action": qsTr("Watch",  "Topic watch action (verb)"), "icon": "image://theme/icon-splus-show-password" }
     ]
-    // level being one of 0, 1, 2, 3; erepresenting muted, normal, tracking, watching
+    // level being one of 0, 1, 2, 3; representing muted, normal, tracking, watching
     // !! payload wants a string so "0", not 0
     function setNotificationLevel(topicid, level){
+        if (loggedin.value == "-1") return
         console.debug("Setting watch level to", level, ",", watchlevel[Number(level)].name)
         var xhr = new XMLHttpRequest;
         const json = {

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -538,11 +538,16 @@ Page {
                         }
 
                         Icon {
-                            visible: has_accepted_answer
-                            source: "image://theme/icon-s-accept"
+                            //visible: has_accepted_answer
+                            //source: "image://theme/icon-s-accept"
+                            visible: source != ""
+                            source: has_accepted_answer ? "image://theme/icon-s-accept?" + Theme.highlightFromColor(Theme.presenceColor(Theme.PresenceAvailable), Theme.colorScheme )
+                                                        : ((notification_level >= 0)
+                                                            ? watchlevel[notification_level].icon + "?" + Theme.rgba(postsLabel.color, 1.0)
+                                                            : "")
                             width: Theme.iconSizeSmall
                             height: width
-                            opacity: Theme.opacityLow
+                            opacity: (notification_level > 1) ? postsLabel.opacity : Theme.opacityLow
                         }
                     }
 


### PR DESCRIPTION
Allows to switch topic tracking level from the context menu.

Not entirely sure about the UI, it fits in the context menu, but maybe it should be somehere else?

Anyway please comment whether something like this would be accepted.

Also, removes the "Don't Track" option without handling the local db changes that did. Are those still needed?

