### PR TITLE
Fix: template-less categories

### DIFF
--- a/qml/harbour-sfos-forum-viewer.qml
+++ b/qml/harbour-sfos-forum-viewer.qml
@@ -91,7 +91,7 @@ ApplicationWindow
                             topic_count: item['topic_count'],
                             description_text: item['description_text'],
                             slug: item['slug'],
-                            topic_template: item['topic_template'],
+                            topic_template: item['topic_template'] || "NO-POSTS-ALLOWED", // need to discern null(no posts allowed) and ""
                             is_subcategory: (!!isSub),
                             parent_category_id: isSub ? item['parent_category_id'] : -1
                         };

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -458,7 +458,7 @@ Page {
             }
             MenuItem {
                 text: qsTr("New thread")
-                visible: !remorseActive && loggedin.value != "-1" && tid ? true : false
+                visible: !remorseActive && loggedin.value != "-1" && tid && topic_template != "NO-POSTS-ALLOWED" ? true : false
                 onClicked: pageStack.push("NewThread.qml", {category: category, raw: topic_template});
             }
             MenuItem {


### PR DESCRIPTION
Currently, the new category "Official Jolla Blog" does not open, beause the template field is `null`
Guard against that.
